### PR TITLE
Make app_client_id optional

### DIFF
--- a/cognitojwt/jwt_async.py
+++ b/cognitojwt/jwt_async.py
@@ -33,7 +33,7 @@ async def get_public_key_async(token: str, region: str, userpool_id: str):
     return jwk.construct(key)
 
 
-async def decode_async(token: str, region: str, userpool_id: str, app_client_id: str, testmode=False) -> dict:
+async def decode_async(token: str, region: str, userpool_id: str, app_client_id: str=None, testmode=False) -> dict:
     message, encoded_signature = str(token).rsplit('.', 1)
 
     decoded_signature = base64url_decode(encoded_signature.encode('utf-8'))
@@ -45,7 +45,9 @@ async def decode_async(token: str, region: str, userpool_id: str, app_client_id:
 
     claims = get_unverified_claims(token)
     check_expired(claims['exp'], testmode=testmode)
-    check_aud(claims['aud'], app_client_id)
+
+    if app_client_id:
+        check_aud(claims['aud'], app_client_id)
 
     return claims
 

--- a/cognitojwt/jwt_async.py
+++ b/cognitojwt/jwt_async.py
@@ -7,7 +7,7 @@ from jose.utils import base64url_decode
 
 from .constants import PUBLIC_KEYS_URL_TEMPLATE
 from .exceptions import CognitoJWTException
-from .token_utils import get_unverified_headers, get_unverified_claims, check_expired, check_aud
+from .token_utils import get_unverified_headers, get_unverified_claims, check_expired, check_client_id
 
 
 @alru_cache(maxsize=1)
@@ -47,7 +47,7 @@ async def decode_async(token: str, region: str, userpool_id: str, app_client_id:
     check_expired(claims['exp'], testmode=testmode)
 
     if app_client_id:
-        check_aud(claims['aud'], app_client_id)
+        check_client_id(claims, app_client_id)
 
     return claims
 

--- a/cognitojwt/jwt_sync.py
+++ b/cognitojwt/jwt_sync.py
@@ -34,7 +34,7 @@ def get_public_key(token: str, region: str, userpool_id: str):
     return jwk.construct(key)
 
 
-def decode(token: str, region: str, userpool_id: str, app_client_id: str, testmode=False) -> dict:
+def decode(token: str, region: str, userpool_id: str, app_client_id: str=None, testmode=False) -> dict:
     message, encoded_signature = str(token).rsplit('.', 1)
 
     decoded_signature = base64url_decode(encoded_signature.encode('utf-8'))
@@ -46,7 +46,9 @@ def decode(token: str, region: str, userpool_id: str, app_client_id: str, testmo
 
     claims = get_unverified_claims(token)
     check_expired(claims['exp'], testmode=testmode)
-    check_aud(claims['aud'], app_client_id)
+
+    if app_client_id:
+        check_aud(claims['aud'], app_client_id)
 
     return claims
 

--- a/cognitojwt/jwt_sync.py
+++ b/cognitojwt/jwt_sync.py
@@ -8,7 +8,7 @@ from jose.utils import base64url_decode
 
 from .constants import PUBLIC_KEYS_URL_TEMPLATE
 from .exceptions import CognitoJWTException
-from .token_utils import get_unverified_claims, get_unverified_headers, check_expired, check_aud
+from .token_utils import get_unverified_claims, get_unverified_headers, check_expired, check_client_id
 
 
 @lru_cache(maxsize=1)
@@ -48,7 +48,7 @@ def decode(token: str, region: str, userpool_id: str, app_client_id: str=None, t
     check_expired(claims['exp'], testmode=testmode)
 
     if app_client_id:
-        check_aud(claims['aud'], app_client_id)
+        check_client_id(claims, app_client_id)
 
     return claims
 

--- a/cognitojwt/token_utils.py
+++ b/cognitojwt/token_utils.py
@@ -1,5 +1,6 @@
 import time
 
+from typing import Dict
 from jose import jwt
 
 from .exceptions import CognitoJWTException
@@ -18,9 +19,16 @@ def check_expired(exp: int, testmode: bool = False) -> None:
         raise CognitoJWTException('Token is expired')
 
 
-def check_aud(aud: str, app_client_id: str) -> None:
-    if aud != app_client_id:
-        raise CognitoJWTException('Token was not issued for this client id')
+def check_client_id(claims: Dict, app_client_id: str) -> None:
+    token_use = claims['token_use']
+
+    if token_use == 'access':
+        if claims['aud'] != app_client_id:
+            raise CognitoJWTException('Token was not issued for this client id audience')
+    elif token_use == 'id':
+        if claims['client_id'] != app_client_id:
+            raise CognitoJWTException('Token was not issued for this client id')
+
 
 
 __all__ = [


### PR DESCRIPTION
I don't really care which app_id was used to sign in to my pool. I would like to make this parameter optional.

Related question: this checks the `aud` field, which is present on the `idToken` returned from cognito. However as far as I can tell you [should use](https://stackoverflow.com/questions/48543948/aws-cognito-whats-the-difference-between-access-and-identity-tokens) the access token for authenticating to your API because it contains less PII. Should it look at `client_id` instead of `aud`? 