### PR TITLE
Local jwks file support for deployment in vpcs without internet gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,6 @@ verified_claims: dict = await cognitojwt.decode_async(
 )
 
 ```
+
+Note: if the application is deployed inside a private vpc without internet gateway, the application will not be able to download the JWKS file.
+In this case set the `AWS_COGNITO_JWSK_PATH` environment variable referencing the absolute or relative path of the jwks.json file.

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ sync_require = [
 ]
 
 async_require = [
+    'aiofile',
     'aiohttp',
     'async_lru'
 ]
@@ -22,7 +23,8 @@ test_require = {
     'aiohttp',
     'async_lru',
     'pytest==4.0.2',
-    'pytest-asyncio'
+    'pytest-asyncio',
+    'attrs==19.1.0'
 }
 
 


### PR DESCRIPTION
If an application is deployed inside a vpc without internet gateway, the application will not be able to download the jwks.json file as there is presently no VPC-endpoint for cognito, therefore an option to supply the jwks file is necessary.

This new feature adds support for an `AWS_COGNITO_JWSK_PATH` environment variable referencing the absolute or relative path of the jwks.json file.