### PR TITLE
Add support for multiple app clients

### DIFF
--- a/cognitojwt/jwt_async.py
+++ b/cognitojwt/jwt_async.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import List, Dict
+from typing import List, Dict, Optional, Union, Container
 
 from aiofile import AIOFile
 import aiohttp
@@ -45,7 +45,7 @@ async def decode_async(
         token: str,
         region: str,
         userpool_id: str,
-        app_client_id: str = None,
+        app_client_id: Optional[Union[str, Container[str]]] = None,
         testmode: bool = False
 ) -> Dict:
     message, encoded_signature = str(token).rsplit('.', 1)

--- a/cognitojwt/jwt_sync.py
+++ b/cognitojwt/jwt_sync.py
@@ -1,7 +1,7 @@
 import json
 import os
 from functools import lru_cache
-from typing import List, Dict
+from typing import List, Dict, Optional, Union, Container
 import requests
 
 
@@ -43,7 +43,7 @@ def decode(
         token: str,
         region: str,
         userpool_id: str,
-        app_client_id: str = None,
+        app_client_id: Optional[Union[str, Container[str]]] = None,
         testmode: bool = False
 ) -> Dict:
     message, encoded_signature = str(token).rsplit('.', 1)

--- a/cognitojwt/token_utils.py
+++ b/cognitojwt/token_utils.py
@@ -1,6 +1,6 @@
 import time
+from typing import Dict, Union, Container
 
-from typing import Dict
 from jose import jwt
 
 from .exceptions import CognitoJWTException
@@ -25,14 +25,17 @@ def check_expired(exp: int, testmode: bool = False) -> None:
         raise CognitoJWTException('Token is expired')
 
 
-def check_client_id(claims: Dict, app_client_id: str) -> None:
+def check_client_id(claims: Dict, app_client_id: Union[str, Container[str]]) -> None:
     token_use = claims['token_use']
 
     client_id_key: str = CLIENT_ID_KEYS.get(token_use)
     if not client_id_key:
         raise CognitoJWTException(f'Invalid token_use: {token_use}. Valid values: {list(CLIENT_ID_KEYS.keys())}')
 
-    if claims[client_id_key] != app_client_id:
+    if isinstance(app_client_id, str):
+        app_client_id = (app_client_id,)
+
+    if claims[client_id_key] not in app_client_id:
         raise CognitoJWTException('Token was not issued for this client id audience')
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,5 +46,8 @@ def test_check_expired():
 def test_check_client_id():
     claims = token_utils.get_unverified_claims(TEST_ACCESS_TOKEN)
     token_utils.check_client_id(claims, AWS_COGNITO_APP_CLIENT_ID)
+    token_utils.check_client_id(claims, ['1001001', AWS_COGNITO_APP_CLIENT_ID])
     with pytest.raises(CognitoJWTException):
         token_utils.check_client_id(claims, '1001001')
+    with pytest.raises(CognitoJWTException):
+        token_utils.check_client_id(claims, f'100{AWS_COGNITO_APP_CLIENT_ID}001')


### PR DESCRIPTION
Allow specifying app_client_id as a container of allowed values to allow authentication from multiple sources.

Achieved using a guard clause to wrap str values in a tuple to avoid breaking the existing interface.

Added test cases:
a list containing both matching and non-matching app_client_ids
a allowed app_client_id with the real value as a substring (to avoid matching `str in str`)